### PR TITLE
"Update announcement service to fix image handling and resizing"

### DIFF
--- a/adapter/mercadolivre/types.go
+++ b/adapter/mercadolivre/types.go
@@ -189,29 +189,22 @@ type AnnouncementsMultiGet []struct {
 			} `json:"values,omitempty"`
 			ValueType string `json:"value_type,omitempty"`
 		} `json:"sale_terms,omitempty"`
-		BuyingMode      string    `json:"buying_mode,omitempty"`
-		ListingTypeID   string    `json:"listing_type_id,omitempty"`
-		StartTime       time.Time `json:"start_time,omitempty"`
-		StopTime        time.Time `json:"stop_time,omitempty"`
-		EndTime         time.Time `json:"end_time,omitempty"`
-		ExpirationTime  time.Time `json:"expiration_time,omitempty"`
-		Condition       string    `json:"condition,omitempty"`
-		Permalink       string    `json:"permalink,omitempty"`
-		ThumbnailID     string    `json:"thumbnail_id,omitempty"`
-		Thumbnail       string    `json:"thumbnail,omitempty"`
-		SecureThumbnail string    `json:"secure_thumbnail,omitempty"`
-		Pictures        []struct {
-			ID        string `json:"id,omitempty"`
-			URL       string `json:"url,omitempty"`
-			SecureURL string `json:"secure_url,omitempty"`
-			Size      string `json:"size,omitempty"`
-			MaxSize   string `json:"max_size,omitempty"`
-			Quality   string `json:"quality,omitempty"`
-		} `json:"pictures,omitempty"`
-		VideoID                      interface{}   `json:"video_id,omitempty"`
-		Descriptions                 []interface{} `json:"descriptions,omitempty"`
-		AcceptsMercadopago           bool          `json:"accepts_mercadopago,omitempty"`
-		NonMercadoPagoPaymentMethods []interface{} `json:"non_mercado_pago_payment_methods,omitempty"`
+		BuyingMode                   string                `json:"buying_mode,omitempty"`
+		ListingTypeID                string                `json:"listing_type_id,omitempty"`
+		StartTime                    time.Time             `json:"start_time,omitempty"`
+		StopTime                     time.Time             `json:"stop_time,omitempty"`
+		EndTime                      time.Time             `json:"end_time,omitempty"`
+		ExpirationTime               time.Time             `json:"expiration_time,omitempty"`
+		Condition                    string                `json:"condition,omitempty"`
+		Permalink                    string                `json:"permalink,omitempty"`
+		ThumbnailID                  string                `json:"thumbnail_id,omitempty"`
+		Thumbnail                    string                `json:"thumbnail,omitempty"`
+		SecureThumbnail              string                `json:"secure_thumbnail,omitempty"`
+		Pictures                     []AnnouncementPicture `json:"pictures,omitempty"`
+		VideoID                      interface{}           `json:"video_id,omitempty"`
+		Descriptions                 []interface{}         `json:"descriptions,omitempty"`
+		AcceptsMercadopago           bool                  `json:"accepts_mercadopago,omitempty"`
+		NonMercadoPagoPaymentMethods []interface{}         `json:"non_mercado_pago_payment_methods,omitempty"`
 		Shipping                     struct {
 			Mode         string        `json:"mode,omitempty"`
 			Methods      []interface{} `json:"methods,omitempty"`
@@ -357,29 +350,22 @@ type Announcement struct {
 		} `json:"values,omitempty"`
 		ValueType string `json:"value_type,omitempty"`
 	} `json:"sale_terms,omitempty"`
-	BuyingMode      string    `json:"buying_mode,omitempty"`
-	ListingTypeID   string    `json:"listing_type_id,omitempty"`
-	StartTime       time.Time `json:"start_time,omitempty"`
-	StopTime        time.Time `json:"stop_time,omitempty"`
-	EndTime         time.Time `json:"end_time,omitempty"`
-	ExpirationTime  time.Time `json:"expiration_time,omitempty"`
-	Condition       string    `json:"condition,omitempty"`
-	Permalink       string    `json:"permalink,omitempty"`
-	ThumbnailID     string    `json:"thumbnail_id,omitempty"`
-	Thumbnail       string    `json:"thumbnail,omitempty"`
-	SecureThumbnail string    `json:"secure_thumbnail,omitempty"`
-	Pictures        []struct {
-		ID        string `json:"id,omitempty"`
-		URL       string `json:"url,omitempty"`
-		SecureURL string `json:"secure_url,omitempty"`
-		Size      string `json:"size,omitempty"`
-		MaxSize   string `json:"max_size,omitempty"`
-		Quality   string `json:"quality,omitempty"`
-	} `json:"pictures,omitempty"`
-	VideoID                      interface{}   `json:"video_id,omitempty"`
-	Descriptions                 []interface{} `json:"descriptions,omitempty"`
-	AcceptsMercadopago           bool          `json:"accepts_mercadopago,omitempty"`
-	NonMercadoPagoPaymentMethods []interface{} `json:"non_mercado_pago_payment_methods,omitempty"`
+	BuyingMode                   string                `json:"buying_mode,omitempty"`
+	ListingTypeID                string                `json:"listing_type_id,omitempty"`
+	StartTime                    time.Time             `json:"start_time,omitempty"`
+	StopTime                     time.Time             `json:"stop_time,omitempty"`
+	EndTime                      time.Time             `json:"end_time,omitempty"`
+	ExpirationTime               time.Time             `json:"expiration_time,omitempty"`
+	Condition                    string                `json:"condition,omitempty"`
+	Permalink                    string                `json:"permalink,omitempty"`
+	ThumbnailID                  string                `json:"thumbnail_id,omitempty"`
+	Thumbnail                    string                `json:"thumbnail,omitempty"`
+	SecureThumbnail              string                `json:"secure_thumbnail,omitempty"`
+	Pictures                     []AnnouncementPicture `json:"pictures,omitempty"`
+	VideoID                      interface{}           `json:"video_id,omitempty"`
+	Descriptions                 []interface{}         `json:"descriptions,omitempty"`
+	AcceptsMercadopago           bool                  `json:"accepts_mercadopago,omitempty"`
+	NonMercadoPagoPaymentMethods []interface{}         `json:"non_mercado_pago_payment_methods,omitempty"`
 	Shipping                     struct {
 		Mode         string        `json:"mode,omitempty"`
 		Methods      []interface{} `json:"methods,omitempty"`
@@ -508,4 +494,13 @@ type PictureUpload struct {
 		URL       string `json:"url,omitempty"`
 	} `json:"variations,omitempty"`
 	Status string `json:"status,omitempty"`
+}
+
+type AnnouncementPicture struct {
+	ID        string `json:"id,omitempty"`
+	URL       string `json:"url,omitempty"`
+	SecureURL string `json:"secure_url,omitempty"`
+	Size      string `json:"size,omitempty"`
+	MaxSize   string `json:"max_size,omitempty"`
+	Quality   string `json:"quality,omitempty"`
 }

--- a/usecases/announcement/dto.go
+++ b/usecases/announcement/dto.go
@@ -15,7 +15,7 @@ type GetAnnouncementsDtoInput struct {
 }
 
 type ImportAnnouncementDtoInput struct {
-	Sku          string    `json:"sku"`
-	StoreOrigin  entity.ID `json:"store_id_origin"`
-	StoreDestiny entity.ID `json:"store_id_destiny"`
+	AnnouncementID string    `json:"announcement_id"`
+	StoreOrigin    entity.ID `json:"store_id_origin"`
+	StoreDestiny   entity.ID `json:"store_id_destiny"`
 }

--- a/usecases/common/mock/mercadolivre_mock.go
+++ b/usecases/common/mock/mercadolivre_mock.go
@@ -10,6 +10,7 @@
 package mock_common
 
 import (
+	image "image"
 	reflect "reflect"
 
 	common "github.com/Vractos/kloni/usecases/common"
@@ -213,6 +214,21 @@ func (mr *MockmeliReaderAnnouncementMockRecorder) GetDescription(id any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDescription", reflect.TypeOf((*MockmeliReaderAnnouncement)(nil).GetDescription), id)
 }
 
+// GetProductsPictures mocks base method.
+func (m *MockmeliReaderAnnouncement) GetProductsPictures(picturesURL []string) ([]image.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProductsPictures", picturesURL)
+	ret0, _ := ret[0].([]image.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProductsPictures indicates an expected call of GetProductsPictures.
+func (mr *MockmeliReaderAnnouncementMockRecorder) GetProductsPictures(picturesURL any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProductsPictures", reflect.TypeOf((*MockmeliReaderAnnouncement)(nil).GetProductsPictures), picturesURL)
+}
+
 // MockmeliWriterAnnouncement is a mock of meliWriterAnnouncement interface.
 type MockmeliWriterAnnouncement struct {
 	ctrl     *gomock.Controller
@@ -282,6 +298,21 @@ func (mr *MockmeliWriterAnnouncementMockRecorder) UpdateQuantity(quantity, annou
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{quantity, announcementId, accessToken}, variationIDs...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQuantity", reflect.TypeOf((*MockmeliWriterAnnouncement)(nil).UpdateQuantity), varargs...)
+}
+
+// ValidateAndExchangeImages mocks base method.
+func (m *MockmeliWriterAnnouncement) ValidateAndExchangeImages(images []*image.Image, accessToken string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAndExchangeImages", images, accessToken)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateAndExchangeImages indicates an expected call of ValidateAndExchangeImages.
+func (mr *MockmeliWriterAnnouncementMockRecorder) ValidateAndExchangeImages(images, accessToken any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndExchangeImages", reflect.TypeOf((*MockmeliWriterAnnouncement)(nil).ValidateAndExchangeImages), images, accessToken)
 }
 
 // MockMercadoLivre is a mock of MercadoLivre interface.
@@ -396,6 +427,21 @@ func (mr *MockMercadoLivreMockRecorder) GetDescription(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDescription", reflect.TypeOf((*MockMercadoLivre)(nil).GetDescription), id)
 }
 
+// GetProductsPictures mocks base method.
+func (m *MockMercadoLivre) GetProductsPictures(picturesURL []string) ([]image.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProductsPictures", picturesURL)
+	ret0, _ := ret[0].([]image.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProductsPictures indicates an expected call of GetProductsPictures.
+func (mr *MockMercadoLivreMockRecorder) GetProductsPictures(picturesURL any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProductsPictures", reflect.TypeOf((*MockMercadoLivre)(nil).GetProductsPictures), picturesURL)
+}
+
 // PublishAnnouncement mocks base method.
 func (m *MockMercadoLivre) PublishAnnouncement(announcementJson []byte, accessToken string) (*string, error) {
 	m.ctrl.T.Helper()
@@ -458,4 +504,19 @@ func (mr *MockMercadoLivreMockRecorder) UpdateQuantity(quantity, announcementId,
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{quantity, announcementId, accessToken}, variationIDs...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQuantity", reflect.TypeOf((*MockMercadoLivre)(nil).UpdateQuantity), varargs...)
+}
+
+// ValidateAndExchangeImages mocks base method.
+func (m *MockMercadoLivre) ValidateAndExchangeImages(images []*image.Image, accessToken string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAndExchangeImages", images, accessToken)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateAndExchangeImages indicates an expected call of ValidateAndExchangeImages.
+func (mr *MockMercadoLivreMockRecorder) ValidateAndExchangeImages(images, accessToken any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndExchangeImages", reflect.TypeOf((*MockMercadoLivre)(nil).ValidateAndExchangeImages), images, accessToken)
 }


### PR DESCRIPTION
This pull request updates the announcement service to fix image handling and resizing. It includes changes to the `GetAnnouncementsIDsViaSKU` and `ImportAnnouncement` functions in the `MercadoLivre` struct. The `GetAnnouncementsIDsViaSKU` function now handles image resizing and validation. The `ImportAnnouncement` function retrieves the announcement using the provided announcement ID and publishes it with the new image URL.